### PR TITLE
NHSO-54995: deprecation and versioning updates

### DIFF
--- a/src/_includes/mobile-menu.njk
+++ b/src/_includes/mobile-menu.njk
@@ -58,17 +58,6 @@
         </a>
       </li>
       <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
-        <a class="nhsuk-header__navigation-link" href="/js-api-specification/">
-          Javascript API Specification
-          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-            aria-hidden="true">
-            <path
-              d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z">
-            </path>
-          </svg>
-        </a>
-      </li>
-      <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
         <a class="nhsuk-header__navigation-link" href="/js-v2-api-specification/">
           Javascript API v2 Specification
           <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"

--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -20,9 +20,6 @@
                     <a class="app-side-nav__link" href="/web-integration-step-by-step/">Web Integration Steps</a>
                   </li>
                   <li class="app-side-nav__item">
-                    <a class="app-side-nav__link" href="/js-api-specification/">Javascript API Specification</a>
-                  </li>
-                  <li class="app-side-nav__item">
                     <a class="app-side-nav__link" href="/js-v2-api-specification/">Javascript API v2 Specification</a>
                   </li>
                 </ul>

--- a/src/js-api-specification.md
+++ b/src/js-api-specification.md
@@ -1,11 +1,21 @@
 ---
 layout: base.njk
-title: Javascript API Specification
+title: Javascript API v1 Specification
 ---
 
 Any application embedded within the NHS App as part of a web integration has access to a limited number of methods to interact with the native Android or iOS Applications using an exposed Javascript interface.
 
 The NHS App JS API must be loaded inline rather than being bundled into the client application codebase. This is so that any changes to the implementation of the API do not require client applications to be recompiled and redeployed.
+
+<div class="nhsuk-warning-callout">
+  <h3 class="nhsuk-warning-callout__label">
+    <span role="text">
+      <span class="nhsuk-u-visually-hidden">Important: </span>
+      Deprecated
+    </span>
+  </h3>
+  <p>This version of the NHS App Javascript API has been deprecated and should not be used for new integrations. Please <a href="/js-v2-api-specification">use version 2</a> for all new integrations and features.</p>
+</div>
 
 To include the Javascript interface:
 

--- a/src/js-v2-api-specification.md
+++ b/src/js-v2-api-specification.md
@@ -5,7 +5,9 @@ title: Javascript API v2 Specification
 
 Any application embedded within the NHS App as part of a web integration has access to a limited number of methods to interact with the native Android or iOS Applications using an exposed Javascript interface.
 
-The NHS App JS API must be loaded inline rather than being bundled into the client application codebase. This is so that any changes to the implementation of the API do not require client applications to be recompiled and redeployed.
+The NHS App JS API should be loaded inline rather than being bundled into the client application codebase. This is so that any changes to the implementation of the API do not require client applications to be recompiled and redeployed.
+
+This specification replaces the version 1 specification, which is deprecated. Documentation for v1 remains [available for reference here](/js-api-specification).
 
 To include the Javascript interface:
 
@@ -21,7 +23,27 @@ Example Usage:
 nhsapp.navigation.goToHomePage()
 ```
 
+## Using newer functionality
+
+The Javascript file may be cached by our client for up to 1 year. If you are updating your code to use newer functionality [(changelog)](/js-v2-api-specification/#changelog) from this library, you should append a query string to the end of the URL to invalidate any existing cache. For example, you could append the date like `?v=2025-07-20` when you start using new functionality.
+
+---
+
+## Changelog <a name="changelog"></a>
+
+### 29 July 2025
+
+* Added `ACCOUNT` appPage option to `goToPage` method.
+
+### 31 January 2025
+
+* Added `GO_BACK` appPage option to `goToPage` method. This allows navigation back to the last page the user visited in the NHS App before the web integration.
+
+---
+
 ## Reference
+
+* [Changelog](/js-v2-api-specification/#changelog)
 * [Tools](/js-v2-api-specification/#tools)
   * [getAppPlatform](/js-v2-api-specification/#getAppPlatform)
   * [isOpenInNHSApp](/js-v2-api-specification/#isOpenInNHSApp)
@@ -35,6 +57,8 @@ nhsapp.navigation.goToHomePage()
 * [Storage](/js-v2-api-specification/#storage)
   * [addToCalendar](/js-v2-api-specification/#addToCalendar)
   * [downloadFromBytes](/js-v2-api-specification/#downloadFromBytes)
+
+---
 
 ### Tools <a name="tools"></a>
 
@@ -307,5 +331,3 @@ nhsapp.storage.downloadFromBytes(
 ##### Status
 
 Live
-
----


### PR DESCRIPTION
- mark v1 of nhsapp.js as deprecated
  - removed from sidebar and now linked via notice in v2
- add changelog and guidance for using newer functionality in v2